### PR TITLE
Add `customError` to the errorProps list.

### DIFF
--- a/src/valid-form.js
+++ b/src/valid-form.js
@@ -18,6 +18,7 @@ export function toggleInvalidClass (input, invalidClass) {
 
 const errorProps = [
   'badInput',
+  'customError',
   'patternMismatch',
   'rangeOverflow',
   'rangeUnderflow',


### PR DESCRIPTION
Add `customError` to the errorProps list to be able to use `input.setCustomValidity('custom-error')` and use `customMessages`.