### PR TITLE
Move `customError` to the last index in the list to be checked as las…

### DIFF
--- a/src/valid-form.js
+++ b/src/valid-form.js
@@ -18,7 +18,6 @@ export function toggleInvalidClass (input, invalidClass) {
 
 const errorProps = [
   'badInput',
-  'customError',
   'patternMismatch',
   'rangeOverflow',
   'rangeUnderflow',
@@ -26,7 +25,8 @@ const errorProps = [
   'tooLong',
   'tooShort',
   'typeMismatch',
-  'valueMissing'
+  'valueMissing',
+  'customError'
 ]
 
 function getCustomMessage (input, customMessages) {


### PR DESCRIPTION
…t prop.

Since `ValidityState.customError` is set to true on each `input.setCustomValidity` invocation, checking it before other props, e.g `patterMismatch`, leads to wrong message display if an input is modified after validation message has been displayed.