### PR TITLE
Fixes insertAfter method

### DIFF
--- a/dist/valid-form.js
+++ b/dist/valid-form.js
@@ -42,9 +42,9 @@ function defaults(obj, defaultObject) {
 
 function insertAfter(refNode, nodeToInsert) {
   var sibling = refNode.nextSibling;
+  var parent = refNode.parentNode;
   if (sibling) {
-    var _parent = refNode.parentNode;
-    _parent.insertBefore(nodeToInsert, sibling);
+    parent.insertBefore(nodeToInsert, sibling);
   } else {
     parent.appendChild(nodeToInsert);
   }

--- a/src/util.js
+++ b/src/util.js
@@ -16,8 +16,8 @@ export function defaults (obj, defaultObject) {
 
 export function insertAfter (refNode, nodeToInsert) {
   const sibling = refNode.nextSibling
+  const parent = refNode.parentNode
   if (sibling) {
-    const parent = refNode.parentNode
     parent.insertBefore(nodeToInsert, sibling)
   } else {
     parent.appendChild(nodeToInsert)


### PR DESCRIPTION
Fixes the`parent undefined` error when using `errorPlacement: 'after'`